### PR TITLE
Multithreaded registration

### DIFF
--- a/notebooks/stabilize_sequence.py
+++ b/notebooks/stabilize_sequence.py
@@ -3,7 +3,7 @@ import numpy as np
 from skimage import transform
 from concurrent.futures import ThreadPoolExecutor
 
-def stabilize_getshifts(im, workers=1):
+def stabilize_getshifts(im):
     """get shifts for sequence
     
     Parameters
@@ -13,7 +13,7 @@ def stabilize_getshifts(im, workers=1):
     returns np.array of shifts
     """
     with ThreadPoolExecutor() as p:
-            shifts= list(p.map(lambda n: imreg.translation(im[n,...], im[n+1,...]), range(im.shape[0]-1)))
+        shifts= list(p.map(lambda n: imreg.translation(im[n,...], im[n+1,...]), range(im.shape[0]-1)))
     shifts=[[0,0]] + shifts
     return np.array(shifts)
 

--- a/notebooks/stabilize_sequence.py
+++ b/notebooks/stabilize_sequence.py
@@ -1,8 +1,9 @@
 import imreg
 import numpy as np
 from skimage import transform
+from concurrent.futures import ThreadPoolExecutor
 
-def stabilize_getshifts(im):
+def stabilize_getshifts(im, workers=1):
     """get shifts for sequence
     
     Parameters
@@ -11,8 +12,9 @@ def stabilize_getshifts(im):
         finds the pairwise shifts
     returns np.array of shifts
     """
-    shifts= map(lambda n: imreg.translation(im[n,...], im[n+1,...]), range(im.shape[0]-1))
-    shifts=[[0,0]] + list(shifts)
+    with ThreadPoolExecutor() as p:
+            shifts= list(p.map(lambda n: imreg.translation(im[n,...], im[n+1,...]), range(im.shape[0]-1)))
+    shifts=[[0,0]] + shifts
     return np.array(shifts)
 
 def stabilize_apply_shifts(seq, shifts):


### PR DESCRIPTION
shifts between frames are embarassingly parallel and apparently imreg releases the GIL (at least I see quite a bit of speedup) so multithreaded execution makes sense